### PR TITLE
vertxdownloader挂死bug修复以及请求超时重试增强

### DIFF
--- a/core/src/main/java/com/cv4j/netdiscovery/core/Spider.java
+++ b/core/src/main/java/com/cv4j/netdiscovery/core/Spider.java
@@ -383,7 +383,7 @@ public class Spider {
 
                     // request正在处理
                     downloader.download(request)
-                            .retryWhen(new RetryWithDelay(maxRetries, retryDelayMillis, request.getUrl())) // 对网络请求的重试机制
+                            .retryWhen(new RetryWithDelay(maxRetries, retryDelayMillis, request)) // 对网络请求的重试机制
                             .map(new Function<Response, Page>() {
 
                                 @Override

--- a/core/src/main/java/com/cv4j/netdiscovery/core/downloader/vertx/VertxDownloader.java
+++ b/core/src/main/java/com/cv4j/netdiscovery/core/downloader/vertx/VertxDownloader.java
@@ -31,7 +31,7 @@ public class VertxDownloader implements Downloader {
 
     private WebClient webClient;
     private io.vertx.reactivex.core.Vertx vertx;
-    private Map<String,String> header;
+    private Map<String, String> header;
     private Set<Cookie> cookieSet;
 
     public VertxDownloader() {
@@ -54,36 +54,36 @@ public class VertxDownloader implements Downloader {
 
                 httpRequest = webClient.getAbs(request.getUrl());
 
-            } else if ("https".equals(request.getUrlParser().getProtocol())){
+            } else if ("https".equals(request.getUrlParser().getProtocol())) {
 
-                httpRequest = webClient.get(443,request.getUrlParser().getHost(),Preconditions.isNotBlank(request.getUrlParser().getQuery())?request.getUrlParser().getPath()+"?"+request.getUrlParser().getQuery():request.getUrlParser().getPath()).ssl(true);
+                httpRequest = webClient.get(443, request.getUrlParser().getHost(), Preconditions.isNotBlank(request.getUrlParser().getQuery()) ? request.getUrlParser().getPath() + "?" + request.getUrlParser().getQuery() : request.getUrlParser().getPath()).ssl(true);
             }
-        } else if (request.getHttpMethod() == HttpMethod.POST){
+        } else if (request.getHttpMethod() == HttpMethod.POST) {
 
             if ("http".equals(request.getUrlParser().getProtocol())) {
 
                 httpRequest = webClient.postAbs(request.getUrl());
 
-            } else if ("https".equals(request.getUrlParser().getProtocol())){
+            } else if ("https".equals(request.getUrlParser().getProtocol())) {
 
-                httpRequest = webClient.post(443,request.getUrlParser().getHost(),Preconditions.isNotBlank(request.getUrlParser().getQuery())?request.getUrlParser().getPath()+"?"+request.getUrlParser().getQuery():request.getUrlParser().getPath()).ssl(true);
+                httpRequest = webClient.post(443, request.getUrlParser().getHost(), Preconditions.isNotBlank(request.getUrlParser().getQuery()) ? request.getUrlParser().getPath() + "?" + request.getUrlParser().getQuery() : request.getUrlParser().getPath()).ssl(true);
             }
         }
 
         //设置请求头header
         if (Preconditions.isNotBlank(header)) {
 
-            for (Map.Entry<String, String> entry:header.entrySet()) {
-                httpRequest.putHeader(entry.getKey(),entry.getValue());
+            for (Map.Entry<String, String> entry : header.entrySet()) {
+                httpRequest.putHeader(entry.getKey(), entry.getValue());
             }
         }
 
         // 针对post请求，需要对header添加一些信息
-        if (request.getHttpMethod()==HttpMethod.POST) {
+        if (request.getHttpMethod() == HttpMethod.POST) {
 
             if (Preconditions.isNotBlank(request.getHttpRequestBody()) && Preconditions.isNotBlank(request.getHttpRequestBody().getContentType())) {
 
-                httpRequest.putHeader(Constant.CONTENT_TYPE ,request.getHttpRequestBody().getContentType());
+                httpRequest.putHeader(Constant.CONTENT_TYPE, request.getHttpRequestBody().getContentType());
             }
         }
 
@@ -97,10 +97,10 @@ public class VertxDownloader implements Downloader {
         HttpRequest<String> stringHttpRequest = httpRequest.as(BodyCodec.string(charset));
         Single<HttpResponse<String>> httpResponseSingle = null;
 
-        if (request.getHttpMethod()==HttpMethod.GET) {
+        if (request.getHttpMethod() == HttpMethod.GET) {
 
             httpResponseSingle = stringHttpRequest.rxSend();
-        } else if (request.getHttpMethod()==HttpMethod.POST) {
+        } else if (request.getHttpMethod() == HttpMethod.POST) {
 
             if (Preconditions.isNotBlank(request.getHttpRequestBody())) {
 
@@ -128,9 +128,9 @@ public class VertxDownloader implements Downloader {
                         if (request.isSaveCookie()) {
 
                             // save cookies
-                            CookieManager.getInsatance().saveCookie(request,cookieSet,stringHttpResponse.cookies());
+                            CookieManager.getInsatance().saveCookie(request, cookieSet, stringHttpResponse.cookies());
                         }
-                        
+
                         return response;
                     }
                 });
@@ -139,7 +139,8 @@ public class VertxDownloader implements Downloader {
     private WebClientOptions initWebClientOptions(Request request) {
 
         WebClientOptions options = new WebClientOptions();
-        options.setKeepAlive(true).setReuseAddress(true).setFollowRedirects(true);
+        options.setKeepAlive(true).setReuseAddress(true).setFollowRedirects(true).setConnectTimeout(10000)
+                .setIdleTimeout(10).setMaxWaitQueueSize(10);
 
         if (Preconditions.isNotBlank(request.getUserAgent())) {
             options.setUserAgent(request.getUserAgent());
@@ -163,7 +164,7 @@ public class VertxDownloader implements Downloader {
 
     public void close() {
 
-        if (webClient!=null) {
+        if (webClient != null) {
             webClient.close();
         }
     }

--- a/core/src/main/java/com/cv4j/netdiscovery/core/utils/RetryWithDelay.java
+++ b/core/src/main/java/com/cv4j/netdiscovery/core/utils/RetryWithDelay.java
@@ -1,5 +1,6 @@
 package com.cv4j.netdiscovery.core.utils;
 
+import com.cv4j.netdiscovery.core.domain.Request;
 import com.safframework.tony.common.utils.Preconditions;
 import io.reactivex.Flowable;
 import io.reactivex.functions.Function;
@@ -14,22 +15,22 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class RetryWithDelay<T> implements Function<Flowable<Throwable>, Publisher<T>> {
 
-    private int retryCount=0;
+    private int retryCount = 0;
     private int maxRetries;
     private int retryDelayMillis;
-    private String url;
+    private Request request;
 
-    public RetryWithDelay(int maxRetries,int retryDelayMillis) {
+    public RetryWithDelay(int maxRetries, int retryDelayMillis) {
 
         this.maxRetries = maxRetries;
         this.retryDelayMillis = retryDelayMillis;
     }
 
-    public RetryWithDelay(int maxRetries,int retryDelayMillis,String url) {
+    public RetryWithDelay(int maxRetries, int retryDelayMillis, Request request) {
 
         this.maxRetries = maxRetries;
         this.retryDelayMillis = retryDelayMillis;
-        this.url = url;
+        this.request = request;
     }
 
     @Override
@@ -39,15 +40,18 @@ public class RetryWithDelay<T> implements Function<Flowable<Throwable>, Publishe
             public Publisher<?> apply(Throwable throwable) throws Exception {
                 if (++retryCount <= maxRetries) {
 
-                    if (Preconditions.isNotBlank(url)) {
+                    if (Preconditions.isNotBlank(request.getUrl())) {
 
-                        log.info("url:"+url+" get error, it will try after " + retryDelayMillis
+                        log.info("url:" + request.getUrl() + " get error, it will try after " + retryDelayMillis
                                 + " millisecond, retry count " + retryCount);
                     } else {
 
                         log.info("get error, it will try after " + retryDelayMillis
                                 + " millisecond, retry count " + retryCount);
                     }
+
+                    // Redo beforeRequest.
+                    request.getBeforeRequest().process(request);
 
                     return Flowable.timer(retryDelayMillis, TimeUnit.MILLISECONDS);
 


### PR DESCRIPTION
vertxdownloader没有设置超时时间，在请求发生异常时不会释放占用的资源，产生挂死现象。现在增加设置超时时间，防止这种情况的发生。此外在超时重试前，选择再次调用request的beforeRequest方法，防止用户的beforeRequest传入的时有状态的内容，重新执行用户的自定义方法，做到完整的请求流程的重试。